### PR TITLE
36 look into some discovered problems

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-REACT_APP_GRAPH_SERVICE= https://gateway.scenwise.nl/graph-service
+REACT_APP_GRAPH_SERVICE= https://graphservice.scenwise.nl
 REACT_APP_MAPBOX_KEY=pk.eyJ1IjoidHVkdGltMjEiLCJhIjoiY2tvYWQwczczMTJ6NTJwbXUydmVvbXFsZCJ9.ixIsrkMIvzJuWoGSMTKZmw

--- a/src/components/TopBar/LocationSearchBar.tsx
+++ b/src/components/TopBar/LocationSearchBar.tsx
@@ -62,7 +62,8 @@ const LocationSearchBar: React.FC = () => {
         return ptRouteFeatures
             .filter((route) => route.properties[field].toLowerCase().includes(value.toLowerCase()))
             .map((route) => route.properties[field])
-            .sortAndUnique();
+            .sort()
+            .filter((v, i, a) => a.indexOf(v) == i);
     };
 
     const handleDepartureChange = (value: string) => {

--- a/src/hooks/filterHook/useInitiateFilterOptions.ts
+++ b/src/hooks/filterHook/useInitiateFilterOptions.ts
@@ -65,5 +65,8 @@ export const getOptions = (
         list = ptRouteFeatures.map((feature) => feature.properties[filter.optionKey]);
     }
 
-    return list.sortAndUnique().filter((option) => option !== '' && option !== null); // Remove undefined values
+    return list
+        .sort()
+        .filter((v, i, a) => a.indexOf(v) == i)
+        .filter((option) => option !== '' && option !== null); // Remove undefined values
 };

--- a/src/methods/apiRequests/addSchedule.ts
+++ b/src/methods/apiRequests/addSchedule.ts
@@ -22,7 +22,6 @@ export const addSchedule = (
                 const originStopName = originStop ? originStop.properties.stopId : ptStopsFeatures[0].properties.stopId;
 
                 const stopIds = ptStopsFeatures.map((feature) => feature.properties.stopId);
-                        // TODO: Sometimes the number of stops of a route from the stop table are not matched the numbers of the schedules
 
                 const groupedSchedules = groupStopsBySequence(schedules, originStopName, stopIds);
 

--- a/src/methods/apiRequests/addSchedule.ts
+++ b/src/methods/apiRequests/addSchedule.ts
@@ -8,35 +8,47 @@ export const addSchedule = (
     routeOrigin: string,
     vehicleIndex: number,
     ptStopsFeatures: PTStopFeature[],
+    ptStops: FeatureRecord<PTStopFeature>,
     setStop: (stop: PTStopFeature) => void,
 ): Promise<void> => {
+    // eslint-disable-next-line sonarjs/cognitive-complexity
     return new Promise(() => {
         const res = getRouteSchedule(routeID);
         res.then((schedules: SchedulePayload[]) => {
             if (schedules.length > 0) {
-                const originStopId = ptStopsFeatures.filter(
+                const originStop = ptStopsFeatures.filter(
                     (stop: PTStopFeature) => stop.properties.stopName === routeOrigin,
-                )[0].properties.stopId;
-                groupStopsBySequence(schedules, originStopId)[vehicleIndex != -1 ? vehicleIndex : 0].forEach(
-                    (schedule: SchedulePayload, index: number) => {
-                        const stopFeature = deepcopy(ptStopsFeatures[index]);
+                )[0];
+                const originStopName = originStop ? originStop.properties.stopId : ptStopsFeatures[0].properties.stopId;
+
+                const stopIds = ptStopsFeatures.map((feature) => feature.properties.stopId);
                         // TODO: Sometimes the number of stops of a route from the stop table are not matched the numbers of the schedules
+
+                const groupedSchedules = groupStopsBySequence(schedules, originStopName, stopIds);
+
+                const schedule = groupedSchedules[vehicleIndex != -1 ? vehicleIndex : 0]
+                    ? groupedSchedules[vehicleIndex != -1 ? vehicleIndex : 0]
+                    : groupedSchedules[0];
+
+                if (schedule.length > 0) {
+                    schedule.forEach((stop) => {
+                        const stopFeature = deepcopy(ptStops[stop.stop_id]);
                         if (stopFeature) {
-                            stopFeature.properties.arrivalTime = schedule.arrival_time;
-                            stopFeature.properties.departureTime = schedule.departure_time;
+                            stopFeature.properties.arrivalTime = stop.arrival_time;
+                            stopFeature.properties.departureTime = stop.departure_time;
                             setStop(stopFeature);
                         }
-                    },
-                );
-            } else {
-                // If no schedule is found, there is no vehicle on the route so no active schedule
-                ptStopsFeatures.forEach((stop: PTStopFeature) => {
-                    const copiedStop = deepcopy(stop);
-                    copiedStop.properties.arrivalTime = 'No active schedule';
-                    copiedStop.properties.departureTime = 'No active schedule';
-                    setStop(copiedStop);
-                });
+                    });
+                    return;
+                }
             }
+            // If no schedule is found, there is no vehicle on the route so no active schedule
+            ptStopsFeatures.forEach((stop: PTStopFeature) => {
+                const copiedStop = deepcopy(stop);
+                copiedStop.properties.arrivalTime = 'No active schedule';
+                copiedStop.properties.departureTime = 'No active schedule';
+                setStop(copiedStop);
+            });
         }).catch((error) => {
             console.error(error);
         });
@@ -49,7 +61,7 @@ export const addSchedule = (
  * @param stops The stop schedule fetched to be splitted
  * @param originId Filter out the schedules from the opposite direction
  */
-const groupStopsBySequence = (stops: SchedulePayload[], originId: string): SchedulePayload[][] => {
+const groupStopsBySequence = (stops: SchedulePayload[], originId: string, stopIds: string[]): SchedulePayload[][] => {
     const groups: SchedulePayload[][] = [];
     let currentGroup: SchedulePayload[] = [];
 
@@ -66,5 +78,24 @@ const groupStopsBySequence = (stops: SchedulePayload[], originId: string): Sched
         groups.push(currentGroup);
     }
 
-    return groups.filter((group) => group[0].stop_id + '' === originId);
+    // Get schedule groups with the correct direction (must contain all stop ids, as stops in different direction have different ids)
+    // Sort the groups based on time
+    // Sometimes there are duplicate stops in the payload, remove them
+    return groups
+        .filter((group) => {
+            return stopIds
+                .filter((id) => !!id)
+                .every((stopId) => {
+                    return group.some((payload) => payload.stop_id + '' === stopId);
+                });
+        })
+        .sort((groupA, groupB) => {
+            const arrivalTimeA = groupA[0].arrival_time;
+            const arrivalTimeB = groupB[0].arrival_time;
+            return arrivalTimeA.localeCompare(arrivalTimeB);
+        })
+        .filter((group, index, array) => {
+            // Check if the arrival time of the first element is unique in the sorted array
+            return index === 0 || group[0].arrival_time !== array[index - 1][0].arrival_time;
+        });
 };

--- a/src/methods/apiRequests/addSchedule.ts
+++ b/src/methods/apiRequests/addSchedule.ts
@@ -29,7 +29,7 @@ export const addSchedule = (
                     ? groupedSchedules[vehicleIndex != -1 ? vehicleIndex : 0]
                     : groupedSchedules[0];
 
-                if (schedule.length > 0) {
+                if (schedule) {
                     schedule.forEach((stop) => {
                         const stopFeature = deepcopy(ptStops[stop.stop_id]);
                         if (stopFeature) {
@@ -50,6 +50,12 @@ export const addSchedule = (
             });
         }).catch((error) => {
             console.error(error);
+            ptStopsFeatures.forEach((stop: PTStopFeature) => {
+                const copiedStop = deepcopy(stop);
+                copiedStop.properties.arrivalTime = error.message;
+                copiedStop.properties.departureTime = error.message;
+                setStop(copiedStop);
+            });
         });
     });
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,24 +1,34 @@
-// Function to limit decimal places to four
-export const limitDecimalPlaces = (coordinates: number[]): number[] => {
-    return [Number(coordinates[0].toFixed(3)), Number(coordinates[1].toFixed(3))];
+// Define the haversine function
+const haversine = (coord1: number[], coord2: number[]): number => {
+    const [lon1, lat1] = coord1;
+    const [lon2, lat2] = coord2;
+    const earthRadius = 6371e3; // Earth radius in meters
+    const degreesToRadians = (degrees: number) => (degrees * Math.PI) / 180;
+    const lat1Rad = degreesToRadians(lat1);
+    const lat2Rad = degreesToRadians(lat2);
+    const deltaLat = degreesToRadians(lat2 - lat1);
+    const deltaLon = degreesToRadians(lon2 - lon1);
+
+    const a =
+        Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+        Math.cos(lat1Rad) * Math.cos(lat2Rad) * Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return earthRadius * c;
 };
 
-// Function to compare arrays by values
-// Return true if two arrays have the same values in the same order
-export const arraysMatch = (arr1: number[], arr2: number[], offset = 0.002): boolean => {
-    return arr1.length === arr2.length && arr1.every((value, index) => Math.abs(value - arr2[index]) <= offset);
-};
+// Function to find the index of the closest point in the route's coordinate list
+export const findClosestPointIndex = (stopCoord: number[], routeCoords: number[][]): number => {
+    let minDistance = Infinity;
+    let closestIndex = -1;
 
-// Add a function to get unique values from array
-declare global {
-    interface Array<T> {
-        unique(): T[];
-        sortAndUnique(): T[];
+    for (let i = 0; i < routeCoords.length; i++) {
+        const distance = haversine(stopCoord, routeCoords[i]);
+        if (distance < minDistance) {
+            minDistance = distance;
+            closestIndex = i;
+        }
     }
-}
-Array.prototype.unique = function <T>(): T[] {
-    return this.filter((v, i, a) => a.indexOf(v) == i);
-};
-Array.prototype.sortAndUnique = function <T>(): T[] {
-    return this.sort().unique();
+
+    return closestIndex;
 };


### PR DESCRIPTION
#36 
- Sort the stops correctly by moving the null stops (null stops were also assigned with a geometry, causing other stops' geometry assigned wrong)
- Improve the algorithm to find the closest point for a stop from the route segment list.
- Sort the schedule list and remove the duplicate schedules
- Filter the schedule list payload by if it contains all the stop IDs ( making the correct direction) and assigns a schedule based on the stop ID instead of assuming the order of the schedule is correct in the list. 
- Remove unnecessary calls to the schedule API and clear the schedule for the stops when another route is selected. 

The following issue is from the original data set and can't be solved here:
- Some routes do not have an original stop
- The original stop sometimes does not exist in the schedule
- Schedule payloads sometimes only contain reversed schedules
- A lot of vehicles do not have an active schedules
- The time of stops in the schedule sometimes does not follow the correct order geographically.